### PR TITLE
Update games.js

### DIFF
--- a/games.js
+++ b/games.js
@@ -51,6 +51,7 @@ var CREATION_ENGINE = 'Creation-Engine'
 var MADNESS = "MADNESS Engine"
 var J_MONKEY_ENGINE = 'jMonkeyEngine'
 var GAMEBRYO = 'Gamebryo'
+var GoldSrc = 'GoldSrc'
 
 
 GAMES = [
@@ -85,7 +86,7 @@ GAMES = [
   {name: 'Argo', engine: RV4, releaseDate: {d: 22, m: 6, y: 2017}, imgId: 'argo', yt: '459VNYwtuS4'}, // Basiert auf Arma 3
   {name: 'Playerunknown\'s Battlegrounds', engine: UNREAL4, releaseDate: {d: 23, m: 3, y: 2017}, imgId: 'PUBG', yt: 'ODWCbu_cuqk'},
   {name: 'Avorion', engine: OWN_ENGINE, releaseDate: {d: 23, m: 1, y: 2017}, imgId: 'avorion', yt: 'PfhIAmnC9kY'}, // https://www.avorion.net/forum/index.php/topic,57.msg306.html?PHPSESSID=jatgosd1226p6nhufid2r5ieu7#msg306
-  {name: 'Half-Life', engine: SOURCE, releaseDate: {d: 8, m: 11, y: 1998}, imgId: 'hl1', yt: '5Wavn29LMrs'},
+  {name: 'Half-Life', engine: GoldSrc, releaseDate: {d: 8, m: 11, y: 1998}, imgId: 'hl1', yt: '5Wavn29LMrs'},
   {name: 'Half-Life 2', engine: SOURCE, releaseDate: {d: 16, m: 11, y: 2004}, imgId: 'hl2', yt: 'S2CSjTa8Jrc'},
   {name: 'Snipperclips', engine: UNITY, releaseDate: {d: 3, m: 3, y: 2017}, imgId: 'snipperclips', yt: 'FAol5oItb2E'}, // https://en.wikipedia.org/wiki/Snipperclips
   {name: 'Firewatch', engine: UNITY, releaseDate: {d: 9, m: 2, y: 2016}, imgId: 'firewatch', yt: 'd02lhvvVSy8'}, // https://madewith.unity.com/en/games/firewatch


### PR DESCRIPTION
Korrektur der Half-Life Engine
Laut Wikipedia ist Half-Life 1 nicht in der Source Engine gebaut, sondern in der GoldSrc Engine. Wahrscheinlich die Engine, aus der irgendwann die Source Engine geworden ist.